### PR TITLE
don't run ray.init when importing from train.py

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -16,7 +16,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 runtime_env = {
     "env_vars": {
-        "ENVIRONMENT": os.environ['ENVIRONMENT'],
+        "ENVIRONMENT": os.environ["ENVIRONMENT"],
     }
 }
 
@@ -217,21 +217,21 @@ def train_func(config):
     return {"final_loss": epoch_loss / len(train_loader)}
 
 
-# Run `make ray_port_forward` ahead of this to make the ray cluster accessible
-ray.init(address="ray://localhost:10001", runtime_env=runtime_env)
+if __name__ == "__main__":
+    # Run `make ray_port_forward` ahead of this to make the ray cluster accessible
+    ray.init(address="ray://localhost:10001", runtime_env=runtime_env)
 
+    with TemporaryDirectory() as results_dir:
+        # Create the trainer
+        trainer = TorchTrainer(
+            train_func,
+            train_loop_config=train_config,
+            scaling_config=scaling_config,
+            run_config=RunConfig(results_dir),
+        )
 
-with TemporaryDirectory() as results_dir:
-    # Create the trainer
-    trainer = TorchTrainer(
-        train_func,
-        train_loop_config=train_config,
-        scaling_config=scaling_config,
-        run_config=RunConfig(results_dir),
-    )
-
-# Start training
-try:
-    results = trainer.fit()
-finally:
-    ray.shutdown()
+    # Start training
+    try:
+        results = trainer.fit()
+    finally:
+        ray.shutdown()


### PR DESCRIPTION
When I import from `train.py` in order to run unit tests, it runs the script, this puts the script running part under `if __name__ == "__main__":`