### PR TITLE
Bug - UV Sync reinstalling dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,7 @@ stop_port_forward:
 		echo "No port forwarding process found"; \
 	fi
 
-install:
-	uv sync
-
-train: install start_port_forward
+train: start_port_forward
 	@trap 'make stop_port_forward' EXIT 2 15; \
 	echo "Training model..." && \
 	RAY_AIR_NEW_OUTPUT=0 uv run --active python training/train.py


### PR DESCRIPTION
Remove uv sync step from make command 
This means that:
* The agent doesn't reinstall dependencies in a local venv at this step
* The agent doesn't uninstall dependencies which were installed in the base pyproject which are not in its immediate dependencies list