### PR TITLE
Add missing pip install commands

### DIFF
--- a/training-infra/templates/dataset_download.yaml
+++ b/training-infra/templates/dataset_download.yaml
@@ -13,6 +13,9 @@ spec:
         - /bin/bash
         - -c
         - |
+          # Install Python packages
+          pip3 install huggingface_hub datasets
+
           # Configure MinIO client
           mc alias set myminio http://minio.minio-internal-{{ .Values.environment }}.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 

--- a/training-infra/templates/weights-download.yaml
+++ b/training-infra/templates/weights-download.yaml
@@ -13,6 +13,9 @@ spec:
         - /bin/bash
         - -c
         - |
+          # Install Hugging Face CLI
+          pip3 install huggingface_hub
+
           # Configure MinIO client
           mc alias set myminio http://minio.minio-internal-{{ .Values.environment }}.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 


### PR DESCRIPTION
The Helm Chart Refactor task solution was no longer working since the pip install commands had been removed from the base job images.

We could also add actual base images to the solution instead, which might be more future-proof, but this seemed like the minimal fix to get the tests working again.